### PR TITLE
Add Diceware passphrase entropy estimator

### DIFF
--- a/modules/jb_bootcamp/jb_bootcamp/__init__.py
+++ b/modules/jb_bootcamp/jb_bootcamp/__init__.py
@@ -4,6 +4,7 @@
 
 from .na_utils import *
 from .bioinfo_dicts import *
+from .diceware import *
 
 __author__ = 'Justin Bois'
 __email__ = 'bois@caltech.edu'

--- a/modules/jb_bootcamp/jb_bootcamp/diceware.py
+++ b/modules/jb_bootcamp/jb_bootcamp/diceware.py
@@ -1,0 +1,89 @@
+"""Utility functions for working with Diceware-style passphrases."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable, Sequence
+
+
+_DEFAULT_SEPARATORS = re.compile(r"[\s._-]+")
+
+
+def _coerce_to_words(passphrase: Iterable[str] | str) -> list[str]:
+    """Return the words contained in ``passphrase``.
+
+    Parameters
+    ----------
+    passphrase:
+        Either an iterable of individual words or a string containing the
+        passphrase. Strings are split on runs of whitespace, periods, dashes,
+        and underscores to mimic the separators commonly used in Diceware
+        phrases.
+
+    Returns
+    -------
+    list[str]
+        The words present in the supplied passphrase. Empty strings are
+        ignored.
+
+    """
+
+    if isinstance(passphrase, str):
+        # ``split`` never returns ``None`` and filters out empty results.
+        return [word for word in _DEFAULT_SEPARATORS.split(passphrase) if word]
+
+    if isinstance(passphrase, Sequence):
+        return [word for word in passphrase if word]
+
+    return [word for word in list(passphrase) if word]
+
+
+def estimate_diceware_entropy(
+    passphrase: Iterable[str] | str,
+    wordlist_size: int = 7776,
+) -> float:
+    """Estimate the entropy, in bits, of a Diceware-style passphrase.
+
+    The entropy of a Diceware passphrase is determined by the number of words
+    chosen and the size of the source word list. This function assumes each
+    word is selected independently and uniformly at random from the list.
+
+    Parameters
+    ----------
+    passphrase:
+        The passphrase whose strength should be estimated. The passphrase can
+        be supplied either as an iterable of already-tokenized words or as a
+        single string. Strings are split using the same rules as
+        :func:`_coerce_to_words`.
+    wordlist_size:
+        The number of entries in the Diceware word list. The classic Diceware
+        list has 7776 entries (six-sided dice rolled five times).
+
+    Returns
+    -------
+    float
+        The estimated number of bits of entropy in the passphrase.
+
+    Raises
+    ------
+    ValueError
+        If ``wordlist_size`` is less than 2 or if no words are detected in the
+        passphrase.
+    """
+
+    if wordlist_size < 2:
+        msg = "wordlist_size must be at least 2"
+        raise ValueError(msg)
+
+    words = _coerce_to_words(passphrase)
+    if not words:
+        msg = "passphrase must contain at least one word"
+        raise ValueError(msg)
+
+    bits_per_word = math.log2(wordlist_size)
+    return len(words) * bits_per_word
+
+
+__all__ = ["estimate_diceware_entropy"]
+

--- a/tests/test_diceware.py
+++ b/tests/test_diceware.py
@@ -1,0 +1,38 @@
+"""Tests for Diceware passphrase utilities."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_ROOT = Path(__file__).resolve().parents[1] / "modules"
+if str(MODULE_ROOT) not in sys.path:
+    sys.path.insert(0, str(MODULE_ROOT))
+
+from jb_bootcamp.jb_bootcamp.diceware import estimate_diceware_entropy
+
+
+def test_entropy_for_dotted_passphrase():
+    passphrase = "Merlot.Hotel.Watch.Dog.fly"
+    expected_bits = 5 * math.log2(7776)
+    assert estimate_diceware_entropy(passphrase) == pytest.approx(expected_bits)
+
+
+def test_entropy_for_iterable_passphrase():
+    passphrase = ["apple", "banana", "cactus"]
+    expected_bits = 3 * math.log2(7776)
+    assert estimate_diceware_entropy(passphrase) == pytest.approx(expected_bits)
+
+
+def test_empty_passphrase_raises():
+    with pytest.raises(ValueError):
+        estimate_diceware_entropy("")
+
+
+def test_small_wordlist_raises():
+    with pytest.raises(ValueError):
+        estimate_diceware_entropy("word", wordlist_size=1)
+


### PR DESCRIPTION
## Summary
- add a utility for estimating entropy of Diceware-style passphrases
- expose the helper through the jb_bootcamp package and add unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5be946a70832abca6356cce6f4995